### PR TITLE
Remove unread and read

### DIFF
--- a/GitHubNotificationManager/GitHubNotificationManagerRedux/Action/NotificationsAction.swift
+++ b/GitHubNotificationManager/GitHubNotificationManagerRedux/Action/NotificationsAction.swift
@@ -26,13 +26,6 @@ struct SearchRequestAction: Action {
     let text: String
 }
 
-struct ReadNotificationAction: Action {
-    let notificationId: NotificationElement.ID
-}
-struct UnReadNotificationAction: Action {
-    let notificationId: NotificationElement.ID
-}
-
 struct NotificationsFetchAction: AsyncAction {
     let watching: WatchingElement?
     var canceller: Canceller

--- a/GitHubNotificationManager/GitHubNotificationManagerRedux/Reducer/NotificationsReducer.swift
+++ b/GitHubNotificationManager/GitHubNotificationManagerRedux/Reducer/NotificationsReducer.swift
@@ -62,26 +62,6 @@ let notificationsReducer: Reducer<NotificationPageState> = { state, action in
         state.notificationsStatuses[index].isVisible = true
         print("notification SubscribeWatchingAction: \(state.notificationsStatuses[index].isVisible)")
         return state
-    case let action as UnReadNotificationAction:
-        guard
-            let pageIndex = state.notificationsStatuses.firstIndex(where: { $0.notifications.map { $0.id }.contains(action.notificationId) }),
-            let notificationIndex = state.notificationsStatuses[pageIndex].notifications.map({ $0.id }).firstIndex(of: action.notificationId)
-            else {
-                fatalError("Unexpected notification for \(action.notificationId)")
-        }
-        var state = state
-        state.notificationsStatuses[pageIndex].notifications[notificationIndex].unread = true
-        return state
-    case let action as ReadNotificationAction:
-        guard
-            let pageIndex = state.notificationsStatuses.firstIndex(where: { $0.notifications.map { $0.id }.contains(action.notificationId) }),
-            let notificationIndex = state.notificationsStatuses[pageIndex].notifications.map({ $0.id }).firstIndex(of: action.notificationId)
-        else {
-            fatalError("Unexpected notification for \(action.notificationId)")
-        }
-        var state = state
-        state.notificationsStatuses[pageIndex].notifications[notificationIndex].unread = false
-        return state
     case _:
         return state
     }

--- a/GitHubNotificationManager/Screen/Notification/List/NotificationListView.Cell.swift
+++ b/GitHubNotificationManager/Screen/Notification/List/NotificationListView.Cell.swift
@@ -11,25 +11,12 @@ import Combine
 import GitHubNotificationManagerNetwork
 
 extension NotificationListView {
-    struct Cell: RenderableView {
-        @EnvironmentObject var store: Store<AppState>
-        
+    struct Cell: View {
         let notification: NotificationElement
         let didSelectCell: (NotificationElement) -> Void
         
         struct Props {
             let notification: NotificationElement
-            let unreadBinding: Binding<Bool>
-        }
-        
-        func map(state: AppState, dispatch: @escaping DispatchFunction) -> Props {
-            Props(
-                notification: notification,
-                unreadBinding: Binding<Bool>(
-                    get: { self.notification.unread },
-                    set: { $0 ? dispatch(UnReadNotificationAction(notificationId: self.notification.id)) : dispatch(ReadNotificationAction(notificationId: self.notification.id)) }
-                )
-            )
         }
         
         var cellGestuer: some Gesture {
@@ -38,20 +25,18 @@ extension NotificationListView {
             }
         }
         
-        func body(props: Props) -> some View {
+        var body: some View {
             HStack {
                 Group {
-                    ImageLoaderView(url: props.notification.repository.owner.avatarURL, defaultImage: UIImage(systemName: "person")!)
+                    ImageLoaderView(url: notification.repository.owner.avatarURL, defaultImage: UIImage(systemName: "person")!)
                         .modifier(ThumbnailImageViewModifier())
                     VStack(alignment: .leading) {
-                        Text(props.notification.repository.fullName).font(.headline).lineLimit(1)
-                        Text(props.notification.subject.title).font(.subheadline).lineLimit(1)
+                        Text(notification.repository.fullName).font(.headline).lineLimit(1)
+                        Text(notification.subject.title).font(.subheadline).lineLimit(1)
                     }
                 }
                 .layoutPriority(DefaultLayoutPriority + 1)
                 .gesture(cellGestuer)
-                Spacer()
-                ReadButton(read: props.unreadBinding)
             }
         }
     }


### PR DESCRIPTION
## What
Remove unread and read action, UI button.

## Why
Because GitHub API is not supported unread and read API for each notification.
https://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository