### PR TITLE
Fix typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Using [SwiftUI](https://developer.apple.com/documentation/swiftui) and [Combine]
 - [Registration GitHub OAuth Apps](https://github.com/settings/developers)
 
 ## Setup
-**NotificationHub** is necessary secret informations for running application.
+**NotificationHub** is necessary secret information for running application.
 You can setup this secret information files with `$make setup`.
 
 ```
@@ -16,7 +16,7 @@ $ make setup
 ```
 
 But it maybe got error about `XXX unbound variable`.
-So, It must be to prepared secret variables as environment variablse when exec `$ make setup`.
+So, It must be to prepared secret variables as environment variables when exec `$ make setup`.
 
 The following environment variables must be prepared.
 


### PR DESCRIPTION
## このPRで対応したこと
- typo と思われるものを修正した
  - `aspell -d en` して確認した

## なぜこのPRが必要だったかの背景・理由
- bannzai はすーぐ typo するから

## TODO・これやらないとということがあれば記載
- ソースコード内は確認してない